### PR TITLE
Patching an alias race condition

### DIFF
--- a/native/source/mixpanel/detail/mixpanel.cpp
+++ b/native/source/mixpanel/detail/mixpanel.cpp
@@ -265,7 +265,6 @@ namespace mixpanel
             Value data;
             data["alias"] = alias;
             track("$create_alias", data);
-            identify(alias);
         }
         else
         {


### PR DESCRIPTION
Calling identify immediately after alias on the newly aliased id has the potential to create duplicate profiles.